### PR TITLE
[Feature] 支持 Android 6.0 (API 23) 设备运行

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ android {
     compileOptions {
         targetCompatibility = JavaVersion.VERSION_17
         sourceCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlin {
@@ -277,6 +278,8 @@ dependencies {
     // UI Tests
     androidTestImplementation(libs.androidx.compose.ui.test)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // Startup Profile & Baseline Profile
     // baselineProfile(project(":macrobenchmark"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ wire = "5.2.1"
 
 compileSdk = "36"
 targetSdk = "35"
-minSdk = "24"
+minSdk = "23"
 
 androidx-appcompat = "1.7.1"
 androidx-activity-compose = "1.10.1"


### PR DESCRIPTION
## 背景
当前项目的 `minSdk = 24`，这意味着应用无法在 Android 6.0 (23) 及更低版本的设备上安装和运行。本次修改旨在降低最低支持版本，使API 23的设备也兼容应用。

## 问题分析
将 `minSdk` 从 24 降低到 23 后，在 Android 6.0 设备上出现错误：
```
java.lang.NoClassDefFoundError: Failed resolution of: Ljava/util/function/Supplier;
```

**根本原因**：
`java.util.function.Supplier` 是 Java 8 引入的类，Android 6.0 原生不支持 Java 8 语言特性，代码或依赖库中使用了 Java 8 的 API

## 解决方案
启用脱糖功能。

## 结果
在安卓6.0的Che1-CL10上正常运行